### PR TITLE
Precisely patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,25 +109,31 @@ module "core" {
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~>1.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | n/a |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | ~> 2.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_core_kv"></a> [core\_kv](#module\_core\_kv) | github.com/Coalfire-CF/terraform-azurerm-key-vault | n/a |
-| <a name="module_diag_la_queries_sa"></a> [diag\_la\_queries\_sa](#module\_diag\_la\_queries\_sa) | github.com/Coalfire-CF/terraform-azurerm-diagnostics | n/a |
-| <a name="module_diag_law"></a> [diag\_law](#module\_diag\_law) | github.com/Coalfire-CF/terraform-azurerm-diagnostics | n/a |
-| <a name="module_diag_sub"></a> [diag\_sub](#module\_diag\_sub) | github.com/Coalfire-CF/terraform-azurerm-diagnostics | n/a |
-| <a name="module_diag_tf_state_sa"></a> [diag\_tf\_state\_sa](#module\_diag\_tf\_state\_sa) | github.com/Coalfire-CF/terraform-azurerm-diagnostics | n/a |
+| <a name="module_core_kv"></a> [core\_kv](#module\_core\_kv) | github.com/Coalfire-CF/terraform-azurerm-key-vault | v1.0.2 |
+| <a name="module_diag_la_queries_sa"></a> [diag\_la\_queries\_sa](#module\_diag\_la\_queries\_sa) | github.com/Coalfire-CF/terraform-azurerm-diagnostics | v1.0.0 |
+| <a name="module_diag_law"></a> [diag\_law](#module\_diag\_law) | github.com/Coalfire-CF/terraform-azurerm-diagnostics | v1.0.0 |
+| <a name="module_diag_sub"></a> [diag\_sub](#module\_diag\_sub) | github.com/Coalfire-CF/terraform-azurerm-diagnostics | v1.0.0 |
+| <a name="module_diag_tf_state_sa"></a> [diag\_tf\_state\_sa](#module\_diag\_tf\_state\_sa) | github.com/Coalfire-CF/terraform-azurerm-diagnostics | v1.0.0 |
 
 ## Resources
 
@@ -168,8 +174,6 @@ No requirements.
 | [azurerm_storage_container.tf_state_lock](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_management_policy.lifecycle_mgmt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_management_policy) | resource |
 | [tls_private_key.xadm](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
-| [azurerm_subscription.primary](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs
 
@@ -178,7 +182,7 @@ No requirements.
 | <a name="input_admin_principal_ids"></a> [admin\_principal\_ids](#input\_admin\_principal\_ids) | admin principal ids | `set(string)` | n/a | yes |
 | <a name="input_app_abbreviation"></a> [app\_abbreviation](#input\_app\_abbreviation) | The prefix for the blob storage account names | `string` | n/a | yes |
 | <a name="input_app_subscription_ids"></a> [app\_subscription\_ids](#input\_app\_subscription\_ids) | The Azure subscription IDs for org microservices | `map(any)` | n/a | yes |
-| <a name="input_azure_private_dns_zones"></a> [azure\_private\_dns\_zones](#input\_azure\_private\_dns\_zones) | List of Private DNS zones to create. | `list(string)` | <pre>[<br>  "privatelink.azurecr.us",<br>  "privatelink.azuredatabricks.net",<br>  "privatelink.database.usgovcloudapi.net",<br>  "privatelink.datafactory.azure.net",<br>  "privatelink.blob.core.usgovcloudapi.net",<br>  "privatelink.table.core.usgovcloudapi.net",<br>  "privatelink.queue.core.usgovcloudapi.net",<br>  "privatelink.file.core.usgovcloudapi.net",<br>  "privatelink.documents.azure.us",<br>  "privatelink.mongo.cosmos.azure.us",<br>  "privatelink.table.cosmos.azure.us",<br>  "privatelink.postgres.database.usgovcloudapi.net",<br>  "privatelink.mysql.database.usgovcloudapi.net",<br>  "privatelink.vaultcore.usgovcloudapi.net",<br>  "privatelink.servicebus.usgovcloudapi.net",<br>  "privatelink.redis.cache.usgovcloudapi.net"<br>]</pre> | no |
+| <a name="input_azure_private_dns_zones"></a> [azure\_private\_dns\_zones](#input\_azure\_private\_dns\_zones) | List of Private DNS zones to create. | `list(string)` | <pre>[<br/>  "privatelink.azurecr.us",<br/>  "privatelink.azuredatabricks.net",<br/>  "privatelink.database.usgovcloudapi.net",<br/>  "privatelink.datafactory.azure.net",<br/>  "privatelink.blob.core.usgovcloudapi.net",<br/>  "privatelink.table.core.usgovcloudapi.net",<br/>  "privatelink.queue.core.usgovcloudapi.net",<br/>  "privatelink.file.core.usgovcloudapi.net",<br/>  "privatelink.documents.azure.us",<br/>  "privatelink.mongo.cosmos.azure.us",<br/>  "privatelink.table.cosmos.azure.us",<br/>  "privatelink.postgres.database.usgovcloudapi.net",<br/>  "privatelink.mysql.database.usgovcloudapi.net",<br/>  "privatelink.vaultcore.usgovcloudapi.net",<br/>  "privatelink.servicebus.usgovcloudapi.net",<br/>  "privatelink.redis.cache.usgovcloudapi.net"<br/>]</pre> | no |
 | <a name="input_cidrs_for_remote_access"></a> [cidrs\_for\_remote\_access](#input\_cidrs\_for\_remote\_access) | admin ciders | `list(any)` | n/a | yes |
 | <a name="input_core_rg_name"></a> [core\_rg\_name](#input\_core\_rg\_name) | Resource group name for core security services | `string` | `"core-rg-1"` | no |
 | <a name="input_custom_private_dns_zones"></a> [custom\_private\_dns\_zones](#input\_custom\_private\_dns\_zones) | List of custom private DNS zones to create. | `list(string)` | `[]` | no |
@@ -187,10 +191,9 @@ No requirements.
 | <a name="input_enable_aad_permissions"></a> [enable\_aad\_permissions](#input\_enable\_aad\_permissions) | Enable/Disable provisioning basic Entra ID level permissions. | `bool` | `true` | no |
 | <a name="input_enable_sub_logs"></a> [enable\_sub\_logs](#input\_enable\_sub\_logs) | Enable/Disable subscription level logging | `bool` | `true` | no |
 | <a name="input_global_tags"></a> [global\_tags](#input\_global\_tags) | Global level tags | `map(string)` | n/a | yes |
-| <a name="input_ip_for_remote_access"></a> [ip\_for\_remote\_access](#input\_ip\_for\_remote\_access) | This is the same as 'cidrs\_for\_remote\_access' but without the /32 on each of the files. The 'ip\_rules' in the storage account will not accept a '/32' address and I gave up trying to strip and convert the values over | `list(any)` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The Azure location/region to create resources in | `string` | n/a | yes |
 | <a name="input_location_abbreviation"></a> [location\_abbreviation](#input\_location\_abbreviation) | The  Azure location/region in 4 letter code | `string` | n/a | yes |
-| <a name="input_private_dns_zone_name"></a> [private\_dns\_zone\_name](#input\_private\_dns\_zone\_name) | The name of the Private DNS Zone. Must be a valid domain name. | `string` | `null` | no |
+| <a name="input_log_analytics_data_collection_rule_id"></a> [log\_analytics\_data\_collection\_rule\_id](#input\_log\_analytics\_data\_collection\_rule\_id) | Optional Log Analytics Data Collection Rule for the workspace. | `string` | `null` | no |
 | <a name="input_regional_tags"></a> [regional\_tags](#input\_regional\_tags) | Regional level tags | `map(string)` | n/a | yes |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | Name prefix used for resources | `string` | n/a | yes |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The Azure subscription ID where resources are being deployed into | `string` | n/a | yes |

--- a/blob_tstate.tf
+++ b/blob_tstate.tf
@@ -1,4 +1,3 @@
-data "azurerm_client_config" "current" {}
 resource "azurerm_storage_account" "tf_state" {
   name                              = length("${local.storage_name_prefix}satfstate") <= 24 ? "${local.storage_name_prefix}satfstate" : "${var.location_abbreviation}mp${var.app_abbreviation}satfstate"
   resource_group_name               = azurerm_resource_group.core.name
@@ -6,7 +5,7 @@ resource "azurerm_storage_account" "tf_state" {
   account_tier                      = "Standard"
   account_replication_type          = "GRS"
   min_tls_version                   = "TLS1_2"
-  enable_https_traffic_only         = true
+  https_traffic_only_enabled        = true
   allow_nested_items_to_be_public   = false
   public_network_access_enabled     = true #controlled with firewall rules 
   infrastructure_encryption_enabled = true
@@ -24,14 +23,6 @@ resource "azurerm_storage_account" "tf_state" {
     versioning_enabled = true
   }
 
-  #removed for testing jun08-2023 -df
-  # network_rules {
-  #   default_action = "Deny"
-  #   ip_rules       = var.ip_for_remote_access
-  #   #virtual_network_subnet_ids = [module.core-vnet.vnet_subnets[2]]
-  #   virtual_network_subnet_ids = var.ip_for_remote_access
-  # }
-
   tags = merge({
     Function = "Storage"
     Plane    = "Core"
@@ -40,10 +31,9 @@ resource "azurerm_storage_account" "tf_state" {
 
 
 resource "azurerm_role_assignment" "tstate_kv_crypto_user" {
-  # for_each             = var.admin_principal_ids
   scope                = module.core_kv.key_vault_id
   role_definition_name = "Key Vault Crypto Service Encryption User"
-  principal_id         = azurerm_storage_account.tf_state.identity.0.principal_id
+  principal_id         = azurerm_storage_account.tf_state.identity[0].principal_id
 }
 
 resource "azurerm_storage_account_customer_managed_key" "enable_tstate_cmk" {
@@ -78,7 +68,7 @@ resource "azurerm_storage_management_policy" "lifecycle_mgmt" {
 }
 
 module "diag_tf_state_sa" {
-  source                = "github.com/Coalfire-CF/terraform-azurerm-diagnostics"
+  source                = "github.com/Coalfire-CF/terraform-azurerm-diagnostics?ref=v1.0.0"
   diag_log_analytics_id = azurerm_log_analytics_workspace.core-la.id
   resource_id           = azurerm_storage_account.tf_state.id
   resource_type         = "sa"

--- a/core_keyvault.tf
+++ b/core_keyvault.tf
@@ -1,5 +1,5 @@
 module "core_kv" {
-  source                          = "github.com/Coalfire-CF/terraform-azurerm-key-vault"
+  source                          = "github.com/Coalfire-CF/terraform-azurerm-key-vault?ref=v1.0.2"
   diag_log_analytics_id           = azurerm_log_analytics_workspace.core-la.id
   kv_name                         = "${var.resource_prefix}-core-kv"
   resource_group_name             = var.core_rg_name

--- a/core_kv_permissions.tf
+++ b/core_kv_permissions.tf
@@ -4,13 +4,3 @@ resource "azurerm_role_assignment" "core_kv_administrator" {
   role_definition_name = "Key Vault Administrator"
   principal_id         = each.key
 }
-
-data "azurerm_subscription" "primary" {
-}
-# resource "azurerm_role_assignment" "core_user_administrator" {
-
-#   for_each             = var.admin_principal_ids
-#   scope                = data.azurerm_subscription.primary.id
-#   role_definition_name = "User Access Administrator"
-#   principal_id         = each.key
-# }

--- a/core_loganalytics.tf
+++ b/core_loganalytics.tf
@@ -19,7 +19,7 @@ resource "azurerm_log_analytics_workspace" "core-la" {
 }
 
 module "diag_law" {
-  source                = "github.com/Coalfire-CF/terraform-azurerm-diagnostics"
+  source                = "github.com/Coalfire-CF/terraform-azurerm-diagnostics?ref=v1.0.0"
   diag_log_analytics_id = azurerm_log_analytics_workspace.core-la.id
   resource_id           = azurerm_log_analytics_workspace.core-la.id
   resource_type         = "law"
@@ -35,7 +35,7 @@ resource "azurerm_storage_account" "law_queries" {
   account_tier                      = "Standard"
   account_replication_type          = "GRS"
   min_tls_version                   = "TLS1_2"
-  enable_https_traffic_only         = true
+  https_traffic_only_enabled         = true
   allow_nested_items_to_be_public   = false
   public_network_access_enabled     = true #controlled with firewall rules 
   infrastructure_encryption_enabled = true
@@ -53,14 +53,6 @@ resource "azurerm_storage_account" "law_queries" {
     versioning_enabled = true
   }
 
-  #removed for testing jun08-2023 -df
-  # network_rules {
-  #   default_action = "Deny"
-  #   ip_rules       = var.ip_for_remote_access
-  #   #virtual_network_subnet_ids = [module.core-vnet.vnet_subnets[2]]
-  #   virtual_network_subnet_ids = var.ip_for_remote_access
-  # }
-
   tags = merge({
     Function = "SIEM"
     Plane    = "Core"
@@ -72,7 +64,7 @@ resource "azurerm_role_assignment" "law_queries_kv_crypto_user" {
   # for_each             = var.admin_principal_ids
   scope                = module.core_kv.key_vault_id
   role_definition_name = "Key Vault Crypto Service Encryption User"
-  principal_id         = azurerm_storage_account.law_queries.identity.0.principal_id
+  principal_id         = azurerm_storage_account.law_queries.identity[0].principal_id
 }
 
 resource "azurerm_storage_account_customer_managed_key" "enable_law_queries_cmk" {
@@ -88,26 +80,8 @@ resource "azurerm_storage_container" "law_queries" {
   container_access_type = "private"
 }
 
-# resource "azurerm_storage_management_policy" "lifecycle_mgmt" {
-#   storage_account_id = azurerm_storage_account.law_queries.id
-
-#   rule {
-#     name    = "deleteAfter90"
-#     enabled = "true"
-#     filters {
-#       prefix_match = ["${var.location_abbreviation}${var.app_abbreviation}tfstatecontainer"]
-#       blob_types   = ["blockBlob"]
-#     }
-#     actions {
-#       version {
-#         delete_after_days_since_creation = 90
-#       }
-#     }
-#   }
-# }
-
 module "diag_la_queries_sa" {
-  source                = "github.com/Coalfire-CF/terraform-azurerm-diagnostics"
+  source                = "github.com/Coalfire-CF/terraform-azurerm-diagnostics?ref=v1.0.0"
   diag_log_analytics_id = azurerm_log_analytics_workspace.core-la.id
   resource_id           = azurerm_storage_account.law_queries.id
   resource_type         = "sa"

--- a/core_loganalytics.tf
+++ b/core_loganalytics.tf
@@ -6,6 +6,7 @@ resource "azurerm_log_analytics_workspace" "core-la" {
   retention_in_days          = 366
   internet_ingestion_enabled = true
   internet_query_enabled     = true
+  data_collection_rule_id    = var.log_analytics_data_collection_rule_id
 
   tags = merge({
     Function = "SIEM"

--- a/entraid.tf
+++ b/entraid.tf
@@ -4,94 +4,34 @@ resource "azurerm_monitor_aad_diagnostic_setting" "aadlogs" {
 
   name                       = "AAD_Logs"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.core-la.id
-  log {
+  enabled_log {
     category = "SignInLogs"
-    enabled  = true
-    retention_policy {
-      enabled = true
-      days    = 365
-    }
   }
-  log {
+  enabled_log {
     category = "AuditLogs"
-    enabled  = true
-    retention_policy {
-      enabled = true
-      days    = 365
-    }
   }
-  log {
+  enabled_log {
     category = "NonInteractiveUserSignInLogs"
-    enabled  = true
-    retention_policy {
-      enabled = true
-      days    = 365
-    }
   }
-  log {
+  enabled_log {
     category = "ServicePrincipalSignInLogs"
-    enabled  = true
-    retention_policy {
-      enabled = true
-      days    = 365
-    }
   }
-  log {
+  enabled_log {
     category = "ManagedIdentitySignInLogs"
-    enabled  = true
-    retention_policy {
-      enabled = true
-      days    = 365
-    }
   }
-  # not supported on Gov Cloud
-  # log {
-  #   category = "ProvisioningLogs"
-  #   enabled  = true
-  #   retention_policy {
-  #     enabled = true
-  #     days    = 365
-  #   }
-  # }
-  log {
+  enabled_log {
     category = "ADFSSignInLogs"
-    enabled  = true
-    retention_policy {
-      enabled = true
-      days    = 365
-    }
   }
-  log {
+  enabled_log {
     category = "RiskyUsers"
-    enabled  = true
-    retention_policy {
-      enabled = true
-      days    = 365
-    }
   }
-  log {
+  enabled_log {
     category = "UserRiskEvents"
-    enabled  = true
-    retention_policy {
-      enabled = true
-      days    = 365
-    }
   }
-
-  log {
+  enabled_log {
     category = "RiskyServicePrincipals"
-    enabled  = false
-    retention_policy {
-      enabled = false
-      days    = 0
-    }
   }
-  log {
+  enabled_log {
     category = "ServicePrincipalRiskEvents"
-    enabled  = false
-    retention_policy {
-      enabled = false
-      days    = 0
-    }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -88,28 +88,12 @@ output "core_xadm_ssh_public_key" {
   description = "Value of the SSH public key for xadm"
 }
 
-# output "core_private_dns_zone_name" {
-#   value = local.enable_private_dns ? azurerm_private_dns_zone.default.0.name : null
-# }
-
 output "core_private_dns_zone_id" {
-  #value = local.enable_private_dns ? azurerm_private_dns_zone.default.0.id : null
-  # value = azurerm_private_dns_zone.default[each.key].id
-  value       = values(azurerm_private_dns_zone.default).*.id
+  value       = values(azurerm_private_dns_zone.default)[*].id
   description = "Private DNS Zone IDs"
 }
 
-# sample
-# output "core_private_dns_zone_id" {
-#   value = {
-#     for k, bd in mso_schema_template_bd.bd : k => bd.name
-#   }
-# }
-
-
 output "core_private_dns_zones" {
-  # value = { for zone in azurerm_private_dns_zone.default : zone.name => zone.id }
-  #  value = azurerm_private_dns_zone.default[each.key].name
-  value       = values(azurerm_private_dns_zone.default).*.name
+  value       = values(azurerm_private_dns_zone.default)[*].name
   description = "Private DNS Zone names"
 }

--- a/required_version.tf
+++ b/required_version.tf
@@ -1,7 +1,14 @@
 terraform {
   required_version = "~>1.0"
-  azurerm = {
+  required_providers {
+    azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 3.45.0"
+      #version = "~> 4.0" # 4.0 isn't compatible with pak currently
     }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.0" # 3.0 appears bugged: https://github.com/hashicorp/terraform-provider-azuread/issues/1526
+    }
+  }
 }

--- a/required_version.tf
+++ b/required_version.tf
@@ -3,8 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      #version = "~> 3.45.0"
-      version = "~> 4.0" # 4.0 isn't compatible with pak currently
+      version = "~> 4.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/required_version.tf
+++ b/required_version.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~>1.0"
+  azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+}

--- a/required_version.tf
+++ b/required_version.tf
@@ -10,5 +10,13 @@ terraform {
       source  = "hashicorp/azuread"
       version = "~> 2.0" # 3.0 appears bugged: https://github.com/hashicorp/terraform-provider-azuread/issues/1526
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
   }
 }

--- a/required_version.tf
+++ b/required_version.tf
@@ -3,8 +3,8 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.45.0"
-      #version = "~> 4.0" # 4.0 isn't compatible with pak currently
+      #version = "~> 3.45.0"
+      version = "~> 4.0" # 4.0 isn't compatible with pak currently
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/subscription_monitor.tf
+++ b/subscription_monitor.tf
@@ -6,10 +6,9 @@
 # Also the sub does not have a diag categories available for query. This is why the
 # sub logs are stored in a var. And sub diag logs are slightly different than other logs.
 
-
 module "diag_sub" {
   count                 = var.enable_sub_logs ? 1 : 0
-  source                = "github.com/Coalfire-CF/terraform-azurerm-diagnostics"
+  source                = "github.com/Coalfire-CF/terraform-azurerm-diagnostics?ref=v1.0.0"
   diag_log_analytics_id = azurerm_log_analytics_workspace.core-la.id
   resource_id           = "/subscriptions/${var.subscription_id}"
   resource_type         = "sub"

--- a/variables.tf
+++ b/variables.tf
@@ -49,11 +49,6 @@ variable "cidrs_for_remote_access" {
   type        = list(any)
 }
 
-variable "ip_for_remote_access" {
-  description = "This is the same as 'cidrs_for_remote_access' but without the /32 on each of the files. The 'ip_rules' in the storage account will not accept a '/32' address and I gave up trying to strip and convert the values over"
-  type        = list(any)
-}
-
 variable "admin_principal_ids" {
   description = "admin principal ids"
   type        = set(string)
@@ -62,12 +57,6 @@ variable "admin_principal_ids" {
 variable "resource_prefix" {
   type        = string
   description = "Name prefix used for resources"
-}
-
-variable "private_dns_zone_name" {
-  type        = string
-  description = "The name of the Private DNS Zone. Must be a valid domain name."
-  default     = null
 }
 
 variable "enable_sub_logs" {

--- a/variables.tf
+++ b/variables.tf
@@ -122,3 +122,9 @@ variable "dr_location" {
   type        = string
   default     = "usgovtexas"
 }
+
+variable "log_analytics_data_collection_rule_id" {
+  description = "Optional Log Analytics Data Collection Rule for the workspace."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
- Updated AzureRM provider from 3.X => 4.X
- Adjusted "azurerm_storage_account" resource "enable_https_traffic_only" => "https_traffic_only_enabled"
- Pointed pak module calls to a specific tag. (tflint)
- Removed all data sources and variables that were declared but not used (tflint).
- Added data_collection_rule_id = var.log_analytics_data_collection_rule_id in the "azurerm_log_analytics_workspace".  In Terraform, this is the ONLY method of associating a Workspace Transformation Data Collection Rule to the Workspace (only 1 allowed per Workspace).
- Adjusted "azurerm_monitor_aad_diagnostic_setting" resource "log" => "enabled_log".  The only accepted parameter for the block is "category".
- Added required_version and required_providers (tflint), used loose versioning to only lock to a major version.