### PR TITLE
Core resource group dependency fixes

### DIFF
--- a/blob_tstate.tf
+++ b/blob_tstate.tf
@@ -1,5 +1,5 @@
 resource "azurerm_storage_account" "tf_state" {
-  depends_on                        = [azurerm.azurerm_resource_group.core]
+  depends_on                        = [azurerm_resource_group.core]
   name                              = length("${local.storage_name_prefix}satfstate") <= 24 ? "${local.storage_name_prefix}satfstate" : "${var.location_abbreviation}mp${var.app_abbreviation}satfstate"
   resource_group_name               = azurerm_resource_group.core.name
   location                          = var.location

--- a/blob_tstate.tf
+++ b/blob_tstate.tf
@@ -1,4 +1,5 @@
 resource "azurerm_storage_account" "tf_state" {
+  depends_on                        = [azurerm.azurerm_resource_group.core]
   name                              = length("${local.storage_name_prefix}satfstate") <= 24 ? "${local.storage_name_prefix}satfstate" : "${var.location_abbreviation}mp${var.app_abbreviation}satfstate"
   resource_group_name               = azurerm_resource_group.core.name
   location                          = var.location

--- a/core_dns.tf
+++ b/core_dns.tf
@@ -1,4 +1,5 @@
 resource "azurerm_private_dns_zone" "default" {
+  depends_on          = [azurerm.azurerm_resource_group.core]
   for_each            = toset(local.private_dns_zones)
   name                = each.value
   resource_group_name = var.core_rg_name

--- a/core_dns.tf
+++ b/core_dns.tf
@@ -1,5 +1,5 @@
 resource "azurerm_private_dns_zone" "default" {
-  depends_on          = [azurerm.azurerm_resource_group.core]
+  depends_on          = [azurerm_resource_group.core]
   for_each            = toset(local.private_dns_zones)
   name                = each.value
   resource_group_name = var.core_rg_name

--- a/core_loganalytics.tf
+++ b/core_loganalytics.tf
@@ -29,13 +29,14 @@ module "diag_law" {
 
 #data "azurerm_client_config" "current" {}
 resource "azurerm_storage_account" "law_queries" {
+  depends_on                        = [azurerm.azurerm_resource_group.core]
   name                              = length("${local.storage_name_prefix}salawqueries") <= 24 ? "${local.storage_name_prefix}salawqueries" : "${var.location_abbreviation}mp${var.app_abbreviation}salawqueries"
   resource_group_name               = azurerm_resource_group.core.name
   location                          = var.location
   account_tier                      = "Standard"
   account_replication_type          = "GRS"
   min_tls_version                   = "TLS1_2"
-  https_traffic_only_enabled         = true
+  https_traffic_only_enabled        = true
   allow_nested_items_to_be_public   = false
   public_network_access_enabled     = true #controlled with firewall rules 
   infrastructure_encryption_enabled = true
@@ -88,6 +89,7 @@ module "diag_la_queries_sa" {
 }
 
 resource "azurerm_log_analytics_linked_storage_account" "law_queries" {
+  depends_on            = [azurerm.azurerm_resource_group.core]
   data_source_type      = "Query"
   resource_group_name   = azurerm_resource_group.core.name
   workspace_resource_id = azurerm_log_analytics_workspace.core-la.id
@@ -95,6 +97,7 @@ resource "azurerm_log_analytics_linked_storage_account" "law_queries" {
 }
 
 resource "azurerm_log_analytics_linked_storage_account" "law_alerts" {
+  depends_on            = [azurerm.azurerm_resource_group.core]
   data_source_type      = "Alerts"
   resource_group_name   = azurerm_resource_group.core.name
   workspace_resource_id = azurerm_log_analytics_workspace.core-la.id

--- a/core_loganalytics.tf
+++ b/core_loganalytics.tf
@@ -29,7 +29,7 @@ module "diag_law" {
 
 #data "azurerm_client_config" "current" {}
 resource "azurerm_storage_account" "law_queries" {
-  depends_on                        = [azurerm.azurerm_resource_group.core]
+  depends_on                        = [azurerm_resource_group.core]
   name                              = length("${local.storage_name_prefix}salawqueries") <= 24 ? "${local.storage_name_prefix}salawqueries" : "${var.location_abbreviation}mp${var.app_abbreviation}salawqueries"
   resource_group_name               = azurerm_resource_group.core.name
   location                          = var.location
@@ -89,7 +89,7 @@ module "diag_la_queries_sa" {
 }
 
 resource "azurerm_log_analytics_linked_storage_account" "law_queries" {
-  depends_on            = [azurerm.azurerm_resource_group.core]
+  depends_on            = [azurerm_resource_group.core]
   data_source_type      = "Query"
   resource_group_name   = azurerm_resource_group.core.name
   workspace_resource_id = azurerm_log_analytics_workspace.core-la.id
@@ -97,7 +97,7 @@ resource "azurerm_log_analytics_linked_storage_account" "law_queries" {
 }
 
 resource "azurerm_log_analytics_linked_storage_account" "law_alerts" {
-  depends_on            = [azurerm.azurerm_resource_group.core]
+  depends_on            = [azurerm_resource_group.core]
   data_source_type      = "Alerts"
   resource_group_name   = azurerm_resource_group.core.name
   workspace_resource_id = azurerm_log_analytics_workspace.core-la.id


### PR DESCRIPTION
Fixed an error where terraform would attempt to create certain resources before `azurerm_resource_group.core`, which would cause those resources to fail upon first apply and succeed during subsequent runs. 

For these resources, a `depends_on = [azurerm_resource_group.core]` block was added.

No README.md updates are necessary for this change.