### PR TITLE
Optionally allow custom resource name inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ module "core" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_principal_ids"></a> [admin\_principal\_ids](#input\_admin\_principal\_ids) | admin principal ids | `set(string)` | n/a | yes |
+| <a name="input_admin_ssh_key_name"></a> [admin\_ssh\_key\_name](#input\_admin\_ssh\_key\_name) | Optional custom name for admin SSH key secret in Key Vault | `string` | `"xadm-ssh-private-key"` | no |
 | <a name="input_app_abbreviation"></a> [app\_abbreviation](#input\_app\_abbreviation) | The prefix for the blob storage account names | `string` | n/a | yes |
 | <a name="input_app_subscription_ids"></a> [app\_subscription\_ids](#input\_app\_subscription\_ids) | The Azure subscription IDs for org microservices | `map(any)` | n/a | yes |
 | <a name="input_azure_private_dns_zones"></a> [azure\_private\_dns\_zones](#input\_azure\_private\_dns\_zones) | List of Private DNS zones to create. | `list(string)` | <pre>[<br/>  "privatelink.azurecr.us",<br/>  "privatelink.azuredatabricks.net",<br/>  "privatelink.database.usgovcloudapi.net",<br/>  "privatelink.datafactory.azure.net",<br/>  "privatelink.blob.core.usgovcloudapi.net",<br/>  "privatelink.table.core.usgovcloudapi.net",<br/>  "privatelink.queue.core.usgovcloudapi.net",<br/>  "privatelink.file.core.usgovcloudapi.net",<br/>  "privatelink.documents.azure.us",<br/>  "privatelink.mongo.cosmos.azure.us",<br/>  "privatelink.table.cosmos.azure.us",<br/>  "privatelink.postgres.database.usgovcloudapi.net",<br/>  "privatelink.mysql.database.usgovcloudapi.net",<br/>  "privatelink.vaultcore.usgovcloudapi.net",<br/>  "privatelink.servicebus.usgovcloudapi.net",<br/>  "privatelink.redis.cache.usgovcloudapi.net"<br/>]</pre> | no |
@@ -206,13 +207,17 @@ module "core" {
 | <a name="input_enable_aad_permissions"></a> [enable\_aad\_permissions](#input\_enable\_aad\_permissions) | Enable/Disable provisioning basic Entra ID level permissions. | `bool` | `true` | no |
 | <a name="input_enable_sub_logs"></a> [enable\_sub\_logs](#input\_enable\_sub\_logs) | Enable/Disable subscription level logging | `bool` | `true` | no |
 | <a name="input_global_tags"></a> [global\_tags](#input\_global\_tags) | Global level tags | `map(string)` | n/a | yes |
+| <a name="input_key_vault_name"></a> [key\_vault\_name](#input\_key\_vault\_name) | Optional custom name for the Security Core Key Vault | `string` | `"default"` | no |
+| <a name="input_law_queries_storage_account_name"></a> [law\_queries\_storage\_account\_name](#input\_law\_queries\_storage\_account\_name) | Optional custom name for the Terraform state Storage Account | `string` | `"default"` | no |
 | <a name="input_location"></a> [location](#input\_location) | The Azure location/region to create resources in | `string` | n/a | yes |
 | <a name="input_location_abbreviation"></a> [location\_abbreviation](#input\_location\_abbreviation) | The  Azure location/region in 4 letter code | `string` | n/a | yes |
 | <a name="input_log_analytics_data_collection_rule_id"></a> [log\_analytics\_data\_collection\_rule\_id](#input\_log\_analytics\_data\_collection\_rule\_id) | Optional Log Analytics Data Collection Rule for the workspace. | `string` | `null` | no |
+| <a name="input_log_analytics_workspace_name"></a> [log\_analytics\_workspace\_name](#input\_log\_analytics\_workspace\_name) | Optional custom name for the Log Analytics Workspace | `string` | `"default"` | no |
 | <a name="input_regional_tags"></a> [regional\_tags](#input\_regional\_tags) | Regional level tags | `map(string)` | n/a | yes |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | Name prefix used for resources | `string` | n/a | yes |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The Azure subscription ID where resources are being deployed into | `string` | n/a | yes |
 | <a name="input_tenant_id"></a> [tenant\_id](#input\_tenant\_id) | The Azure tenant ID that owns the deployed resources | `string` | n/a | yes |
+| <a name="input_tfstate_storage_account_name"></a> [tfstate\_storage\_account\_name](#input\_tfstate\_storage\_account\_name) | Optional custom name for the Terraform state Storage Account | `string` | `"default"` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,22 @@ module "core" {
   #fw_virtual_network_subnet_ids = data.terraform_remote_state.usgv_mgmt_vnet.outputs.usgv_mgmt_vnet_subnet_ids["${local.resource_prefix}-bastion-sn-1"] #Uncomment and rerun terraform apply after the mgmt-network is created
 }
 ```
+### Optional - custom resource names
+You may optionally supply custom names for all resources created by this module, to support various naming convention requirements: 
 
+```hcl
+module "core" {
+...
+  core_rg_name                     = "arbitrary-resource-group-name"
+  admin_ssh_key_name               = "arbitrary-ssh-key-name"
+  key_vault_name                   = "arbitrary-key-vault-name"
+  tfstate_storage_account_name     = "tfstatestorageaccountname"
+  law_queries_storage_account_name = "lawquerystorageaccountname"
+  log_analytics_workspace_name     = "arbitrary-log-analytics-workspace-name"
+...
+}
+
+```
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/blob_tstate.tf
+++ b/blob_tstate.tf
@@ -1,6 +1,6 @@
 resource "azurerm_storage_account" "tf_state" {
   depends_on                        = [azurerm_resource_group.core]
-  name                              = length("${local.storage_name_prefix}satfstate") <= 24 ? "${local.storage_name_prefix}satfstate" : "${var.location_abbreviation}mp${var.app_abbreviation}satfstate"
+  name                              = local.tfstate_storage_account_name
   resource_group_name               = azurerm_resource_group.core.name
   location                          = var.location
   account_tier                      = "Standard"

--- a/core_keyvault.tf
+++ b/core_keyvault.tf
@@ -1,7 +1,7 @@
 module "core_kv" {
   source                          = "github.com/Coalfire-CF/terraform-azurerm-key-vault?ref=v1.0.2"
   diag_log_analytics_id           = azurerm_log_analytics_workspace.core-la.id
-  kv_name                         = "${var.resource_prefix}-core-kv"
+  kv_name                         = local.key_vault_name
   resource_group_name             = var.core_rg_name
   location                        = var.location
   tenant_id                       = var.tenant_id

--- a/core_keyvault.tf
+++ b/core_keyvault.tf
@@ -200,7 +200,7 @@ resource "tls_private_key" "xadm" {
 }
 
 resource "azurerm_key_vault_secret" "xadm_ssh" {
-  name         = "xadm-ssh-private-key"
+  name         = var.admin_ssh_key_name
   value        = base64encode(tls_private_key.xadm.private_key_openssh)
   key_vault_id = module.core_kv.key_vault_id
   content_type = "ssh-key"

--- a/core_loganalytics.tf
+++ b/core_loganalytics.tf
@@ -30,7 +30,7 @@ module "diag_law" {
 #data "azurerm_client_config" "current" {}
 resource "azurerm_storage_account" "law_queries" {
   depends_on                        = [azurerm_resource_group.core]
-  name                              = length("${local.storage_name_prefix}salawqueries") <= 24 ? "${local.storage_name_prefix}salawqueries" : "${var.location_abbreviation}mp${var.app_abbreviation}salawqueries"
+  name                              = local.law_queries_storage_account_name
   resource_group_name               = azurerm_resource_group.core.name
   location                          = var.location
   account_tier                      = "Standard"

--- a/core_loganalytics.tf
+++ b/core_loganalytics.tf
@@ -1,5 +1,5 @@
 resource "azurerm_log_analytics_workspace" "core-la" {
-  name                       = "${var.resource_prefix}-la-1"
+  name                       = local.log_analytics_workspace_name
   location                   = var.location
   resource_group_name        = azurerm_resource_group.core.name
   sku                        = "PerGB2018"

--- a/locals.tf
+++ b/locals.tf
@@ -23,7 +23,8 @@ locals {
     ]
   }
   private_dns_zones = distinct(concat(var.azure_private_dns_zones, var.custom_private_dns_zones, flatten(values(local.regional_private_dns_zones))))
-}
 
-# default resource names
-key_vault_name = var.key_vault_name != "default" ? var.key_vault_name : "${var.resource_prefix}-core-kv"
+
+  # default resource names
+  key_vault_name = var.key_vault_name != "default" ? var.key_vault_name : "${var.resource_prefix}-core-kv"
+}

--- a/locals.tf
+++ b/locals.tf
@@ -29,4 +29,5 @@ locals {
   key_vault_name                   = var.key_vault_name != "default" ? var.key_vault_name : "${var.resource_prefix}-core-kv"
   tfstate_storage_account_name     = var.tfstate_storage_account_name != "default" ? var.tfstate_storage_account_name : length("${local.storage_name_prefix}satfstate") <= 24 ? "${local.storage_name_prefix}satfstate" : "${var.location_abbreviation}mp${var.app_abbreviation}satfstate"
   law_queries_storage_account_name = var.law_queries_storage_account_name != "default" ? var.law_queries_storage_account_name : length("${local.storage_name_prefix}salawqueries") <= 24 ? "${local.storage_name_prefix}salawqueries" : "${var.location_abbreviation}mp${var.app_abbreviation}salawqueries"
+  log_analytics_workspace_name     = var.log_analytics_workspace_name != "default" ? var.loganalytics_workspace_name : "${var.resource_prefix}-la-1"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -29,5 +29,5 @@ locals {
   key_vault_name                   = var.key_vault_name != "default" ? var.key_vault_name : "${var.resource_prefix}-core-kv"
   tfstate_storage_account_name     = var.tfstate_storage_account_name != "default" ? var.tfstate_storage_account_name : length("${local.storage_name_prefix}satfstate") <= 24 ? "${local.storage_name_prefix}satfstate" : "${var.location_abbreviation}mp${var.app_abbreviation}satfstate"
   law_queries_storage_account_name = var.law_queries_storage_account_name != "default" ? var.law_queries_storage_account_name : length("${local.storage_name_prefix}salawqueries") <= 24 ? "${local.storage_name_prefix}salawqueries" : "${var.location_abbreviation}mp${var.app_abbreviation}salawqueries"
-  log_analytics_workspace_name     = var.log_analytics_workspace_name != "default" ? var.loganalytics_workspace_name : "${var.resource_prefix}-la-1"
+  log_analytics_workspace_name     = var.log_analytics_workspace_name != "default" ? var.log_analytics_workspace_name : "${var.resource_prefix}-la-1"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -26,5 +26,6 @@ locals {
 
 
   # default resource names
-  key_vault_name = var.key_vault_name != "default" ? var.key_vault_name : "${var.resource_prefix}-core-kv"
+  key_vault_name               = var.key_vault_name != "default" ? var.key_vault_name : "${var.resource_prefix}-core-kv"
+  tfstate_storage_account_name = var.tfstate_storage_account_name != "default" ? var.tfstate_storage_account_name : length("${local.storage_name_prefix}satfstate") <= 24 ? "${local.storage_name_prefix}satfstate" : "${var.location_abbreviation}mp${var.app_abbreviation}satfstate"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -24,3 +24,6 @@ locals {
   }
   private_dns_zones = distinct(concat(var.azure_private_dns_zones, var.custom_private_dns_zones, flatten(values(local.regional_private_dns_zones))))
 }
+
+# default resource names
+key_vault_name = var.key_vault_name != "default" ? var.key_vault_name : "${var.resource_prefix}-core-kv"

--- a/locals.tf
+++ b/locals.tf
@@ -26,6 +26,7 @@ locals {
 
 
   # default resource names
-  key_vault_name               = var.key_vault_name != "default" ? var.key_vault_name : "${var.resource_prefix}-core-kv"
-  tfstate_storage_account_name = var.tfstate_storage_account_name != "default" ? var.tfstate_storage_account_name : length("${local.storage_name_prefix}satfstate") <= 24 ? "${local.storage_name_prefix}satfstate" : "${var.location_abbreviation}mp${var.app_abbreviation}satfstate"
+  key_vault_name                   = var.key_vault_name != "default" ? var.key_vault_name : "${var.resource_prefix}-core-kv"
+  tfstate_storage_account_name     = var.tfstate_storage_account_name != "default" ? var.tfstate_storage_account_name : length("${local.storage_name_prefix}satfstate") <= 24 ? "${local.storage_name_prefix}satfstate" : "${var.location_abbreviation}mp${var.app_abbreviation}satfstate"
+  law_queries_storage_account_name = var.law_queries_storage_account_name != "default" ? var.law_queries_storage_account_name : length("${local.storage_name_prefix}salawqueries") <= 24 ? "${local.storage_name_prefix}salawqueries" : "${var.location_abbreviation}mp${var.app_abbreviation}salawqueries"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -126,4 +126,29 @@ variable "key_vault_name" {
     condition     = can(regex("^[a-zA-Z0-9-]{3,24}$", var.key_vault_name))
     error_message = "Key Vault names must be between 3 and 24 characters long and can only contain letters, numbers and dashes."
   }
+  validation {
+    error_message = "Key Vault names must not contain two consecutive dashes"
+    condition     = !can(regex("--", var.key_vault_name))
+  }
+  validation {
+    error_message = "Key Vault names must start with a letter"
+    condition     = can(regex("^[a-zA-Z]", var.key_vault_name))
+  }
+  validation {
+    error_message = "Key Vault names must end with a letter or number"
+    condition     = can(regex("[a-zA-Z0-9]$", var.key_vault_name))
+  }
+}
+variable "tfstate_storage_account_name" {
+  description = "Optional custom name for the Terraform state Storage Account"
+  type        = string
+  default     = "default"
+  validation {
+    condition     = length(var.tfstate_storage_account_name) < 25 && length(var.tfstate_storage_account_name) > 2
+    error_message = "Storage account names must be between 3 and 24 characters in length"
+  }
+  validation {
+    condition     = can(regex("^[0-9a-z]+$", var.tfstate_storage_account_name))
+    error_message = "Storage account names must contain only lowercase letters and numbers"
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -152,3 +152,16 @@ variable "tfstate_storage_account_name" {
     error_message = "Storage account names must contain only lowercase letters and numbers"
   }
 }
+variable "law_queries_storage_account_name" {
+  description = "Optional custom name for the Terraform state Storage Account"
+  type        = string
+  default     = "default"
+  validation {
+    condition     = length(var.law_queries_storage_account_name) < 25 && length(var.law_queries_storage_account_name) > 2
+    error_message = "Storage account names must be between 3 and 24 characters in length"
+  }
+  validation {
+    condition     = can(regex("^[0-9a-z]+$", var.law_queries_storage_account_name))
+    error_message = "Storage account names must contain only lowercase letters and numbers"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -165,3 +165,14 @@ variable "law_queries_storage_account_name" {
     error_message = "Storage account names must contain only lowercase letters and numbers"
   }
 }
+variable "log_analytics_workspace_name" {
+  description = "Optional custom name for the Log Analytics Workspace"
+  type        = string
+  default     = "default"
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-]{4,63}$", var.log_analytics_workspace_name))
+    error_message = "Log Analytics Workspace names must be between 4 and 63 characters long and can only contain letters, numbers and dashes."
+  }
+}
+
+

--- a/variables.tf
+++ b/variables.tf
@@ -174,5 +174,9 @@ variable "log_analytics_workspace_name" {
     error_message = "Log Analytics Workspace names must be between 4 and 63 characters long and can only contain letters, numbers and dashes."
   }
 }
-
+variable "admin_ssh_key_name" {
+  description = "Optional custom name for admin SSH key secret in Key Vault"
+  type        = string
+  default     = "xadm-ssh-private-key"
+}
 

--- a/variables.tf
+++ b/variables.tf
@@ -117,3 +117,13 @@ variable "log_analytics_data_collection_rule_id" {
   type        = string
   default     = null
 }
+
+variable "key_vault_name" {
+  description = "Optional custom name for the Security Core Key Vault"
+  type        = string
+  default     = "default"
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-]{3,24}$", var.key_vault_name))
+    error_message = "Key Vault names must be between 3 and 24 characters long and can only contain letters, numbers and dashes."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -118,6 +118,7 @@ variable "log_analytics_data_collection_rule_id" {
   default     = null
 }
 
+### Optional custom name inputs ###
 variable "key_vault_name" {
   description = "Optional custom name for the Security Core Key Vault"
   type        = string


### PR DESCRIPTION
- Added optional input variables for the following:
  -  core_rg_name
  - admin_ssh_key_name (useful if a duplicate-named keyvault secret already exists in soft-deleted state)
  - key_vault_name
  - tfstate_storage_account_name
  - law_queries_storage_account_name
  - log_analytics_workspace_name
- If these variables are not set, the input variable is passed into locals.tf and replaced with its previously hardcoded value
- This update introduces no breaking changes from v1.0.2 ; existing pak deployments using v1.0.2 will be unaffected if updated to this version
- Storage account names have validation set to constrain inputs to 3-24 characters and lowercase/numbers only
- Log Analytics Workspace name is constrained to 4-63 characters including only letters, numbers, and dashes
- Key Vault name validation is set to constrain inputs to the following
  - 3-24 character length
  - may contain only letters, numbers and dashes
  - cannot start or end with a dash
  - cannot contain consecutive dashes
- Updated README to document additional input vars